### PR TITLE
return if current buffer is not loaded

### DIFF
--- a/lua/yanil/canvas.lua
+++ b/lua/yanil/canvas.lua
@@ -267,6 +267,7 @@ function M.on_section_changed(section, changes, linenr_offset)
 end
 
 function M.in_edit_mode(fn)
+    if not vim.api.nvim_buf_is_loaded(M.bufnr) then return end
     api.nvim_buf_set_option(M.bufnr, "modifiable", true)
     local ok, err = pcall(fn)
     if not ok then api.nvim_err_writeln(err) end


### PR DESCRIPTION
If you setup a user autocmd when the git status is changed, but the filetree buffer is not loaded, `canvas.in_edit_mode` will throw an error saying "invalid buffer id".

https://user-images.githubusercontent.com/2835826/109981095-93389c00-7cce-11eb-83bb-282196e77670.mp4


This PR will first to see if the buffer is loaded before moving on with the rest of the function.


https://user-images.githubusercontent.com/2835826/109981427-e27ecc80-7cce-11eb-80ee-303e3129a5ce.mp4

Cheers, and thank you for the great plugin! 